### PR TITLE
Added multi-stage build to ChuckService

### DIFF
--- a/ChuckService/Dockerfile
+++ b/ChuckService/Dockerfile
@@ -1,9 +1,11 @@
+FROM maven:3.5.2-jdk-8-alpine AS MavenBuild
+COPY pom.xml /tmp/
+COPY src /tmp/src/
+WORKDIR /tmp/
+RUN mvn package
+
 FROM openjdk:8u181-alpine
-
 RUN ["mkdir", "/app"]
-
 WORKDIR /app
-
-ADD target/chuck-service.jar .
-
+COPY --from=MavenBuild /tmp/target/chuck-service*.jar ./chuck-service.jar
 ENTRYPOINT ["java", "-jar", "./chuck-service.jar"]

--- a/ChuckService/pom.xml
+++ b/ChuckService/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>org.nvisia.openliberty</groupId>
 	<artifactId>chuck-service</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
-	<packaging>war</packaging>
+	<packaging>jar</packaging>
 
 	<name>Chuck Service</name>
 	<description>Simple Service that returns random Chuck Norris jokes for use ... anywhere</description>


### PR DESCRIPTION
@jgitter this is the general idea of using docker to build everything from source - implemented in for ChuckService. I wasn't sure how you manually got the .jar since "mvn package" creates a war, so i hacked the packaging in the POM spit out a Jar. That needs to be fixed as you'll get a "no main manifest attribute, in ./chuck-service.jar" error. I'd dig further but I am out of time. Hope this helps.